### PR TITLE
fix more todos

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -10,6 +10,6 @@
         "timonwong.shellcheck"
       ]
     }
-  },
+  }
   // "postStartCommand": "pre-commit install"
 }

--- a/README.md
+++ b/README.md
@@ -19,12 +19,7 @@ Now just clone a repository containing a devcontainer configuration and select
 
 -   Check for the existence of various things which it is assumed do not exist.
 -   Increase robustness of Multipass calls, which seem to occasionally fail.
--   Make key generation non-interactive.
--   Try to figure out a test suite.
--   Assumes zsh.
--   Check if the avahi stuff from [this
-    repo](https://github.com/magnetikonline/macos-multipass-docker) helps with
-    hostname persistence.
+-   Add a test suite.
 
 ## License
 

--- a/install.sh
+++ b/install.sh
@@ -3,10 +3,9 @@ set -euxo pipefail
 
 mkdir -p "$HOME"/.local/bin "$HOME"/.docker/cli-plugins
 
+export PATH=$PATH:$HOME/.local/bin
 # shellcheck disable=SC2016
-echo 'export PATH=$PATH:$HOME/.local/bin' >>"$HOME"/.zshrc
-# shellcheck source=/dev/null
-source "$HOME"/.zshrc
+echo 'export PATH=$PATH:$HOME/.local/bin' | tee -a "$HOME"/.zshrc "$HOME"/.bash_profile
 
 # Install Multipass.
 curl -o multipass.pkg -SL https://github.com/canonical/multipass/releases/download/v1.12.0/multipass-1.12.0+mac-Darwin.pkg
@@ -40,16 +39,15 @@ multipass set client.primary-name=docker
 
 # Copy the local user's SSH key to the VM.
 mkdir "$HOME"/.ssh
-ssh-keygen -t ed25519 -C "$USER"
+ssh-keygen -t ed25519 -C "$USER" -f id_ed25519 -N ""
 mv id_ed25519* "$HOME"/.ssh/
 multipass <~/.ssh/id_ed25519.pub exec docker -- bash -c 'cat -- >> .ssh/authorized_keys'
 
 # Add SSH configuration for the local Docker VM.
-VM_IP=$(multipass ls --format csv | grep docker | cut -d ',' -f 3)
 cat <<EOF >>~/.ssh/config
 Host docker.local
-  HostName $VM_IP
   User ubuntu
+  ProxyCommand bash -c "nc $(multipass ls --format csv | grep docker | cut -d ',' -f 3) %p"
 EOF
 
 # Add a Docker context pointing to the VM and select it.


### PR DESCRIPTION
- Use a `ProxyCommand` to get the Docker VM's IP dynamically.
- Update `$PATH` in both bash and zsh.
- Make key generation non-interactive.