### PR TITLE
fix(installer): :bug: fix error when ssh directory already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ This script will install Multipass from scratch on MacOS.
 
 Visual Studio Code is not needed for the install, but needed to make use of it.
 
+## Prerequisites
+
+The script should need absolutely nothing to run from a fresh install. However
+you will need git to download it in the first place, so open a terminal and
+enter:
+
+```sh
+xcode-select --install
+```
+
 ## Usage
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Now just clone a repository containing a devcontainer configuration and select
 When initially running the installer script, make sure you cloned to somewhere
 other than a protected MacOS directory (such as `Desktop`). The recommended
 option is to create `$HOME/Developer` (which MacOS automatically assigns a nice
-icon) and clone to there. Otherewise you may get mounting issues where Docker
+icon) and clone to there. Otherwise you may get mounting issues where Docker
 complains that the current directory doesn't exist.
 
 If the Docker VM ever gets into a state where it won't launch, then delete it

--- a/README.md
+++ b/README.md
@@ -15,6 +15,29 @@ Enter your password when prompted.
 Now just clone a repository containing a devcontainer configuration and select
 `Reopen in Container` to open it in the Docker VM.
 
+## Troubleshooting
+
+When initially running the installer script, make sure you cloned to somewhere
+other than a protected MacOS directory (such as `Desktop`). The recommended
+option is to create `$HOME/Developer` (which MacOS automatically assigns a nice
+icon) and clone to there. Otherewise you may get mounting issues where Docker
+complains that the current directory doesn't exist.
+
+If the Docker VM ever gets into a state where it won't launch, then delete it
+and launch it again. This means you'll need to re-add keys (and remove the old
+ones from your keystore) and re-mount your home directory:
+
+```sh
+multipass delete docker
+multipass purge
+multipass launch docker
+multipass stop docker
+multipass mount --type native "$HOME" docker
+multipass start docker
+multipass <~/.ssh/id_ed25519.pub exec docker -- bash -c 'cat -- >> ~/.ssh/authorized_keys'
+ssh-keygen -R docker.local
+```
+
 ## TODO
 
 -   Check for the existence of various things which it is assumed do not exist.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Multipass installer
 
-This script will install Multipass from scratch on MacOS.
+This script will install Docker via Multipass from scratch on MacOS.
 
 Visual Studio Code is not needed for the install, but needed to make use of it.
 
@@ -50,8 +50,6 @@ ssh-keygen -R docker.local
 
 ## TODO
 
--   Check for the existence of various things which it is assumed do not exist.
--   Increase robustness of Multipass calls, which seem to occasionally fail.
 -   Add a test suite.
 
 ## License

--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ multipass start docker
 multipass set client.primary-name=docker
 
 # Copy the local user's SSH key to the VM.
-mkdir "$HOME"/.ssh
+mkdir -p "$HOME"/.ssh
 ssh-keygen -t ed25519 -C "$USER" -f id_ed25519 -N ""
 mv id_ed25519* "$HOME"/.ssh/
 multipass <~/.ssh/id_ed25519.pub exec docker -- bash -c 'cat -- >> ~/.ssh/authorized_keys'

--- a/install.sh
+++ b/install.sh
@@ -8,9 +8,7 @@ if [ "$(uname)" != "Darwin" ]; then
 fi
 
 # Create directories.
-[ ! -d "$HOME/.local/bin" ] && mkdir -p "$HOME/.local/bin"
-[ ! -d "$HOME/.docker/cli-plugins" ] && mkdir -p "$HOME/.docker/cli-plugins"
-[ ! -d "$HOME/.ssh" ] && mkdir -p "$HOME/.ssh"
+mkdir -p "$HOME/.local/bin" "$HOME/.docker/cli-plugins" "$HOME/.ssh"
 
 export PATH=$PATH:$HOME/.local/bin
 # shellcheck disable=SC2016

--- a/install.sh
+++ b/install.sh
@@ -8,9 +8,9 @@ if [ "$(uname)" != "Darwin" ]; then
 fi
 
 # Create directories.
-[ -d "$HOME/.local/bin" ] && mkdir -p "$HOME/.local/bin"
-[ -d "$HOME/.docker/cli-plugins" ] && mkdir -p "$HOME/.docker/cli-plugins"
-[ -d "$HOME/.ssh" ] && mkdir -p "$HOME/.ssh"
+[ ! -d "$HOME/.local/bin" ] && mkdir -p "$HOME/.local/bin"
+[ ! -d "$HOME/.docker/cli-plugins" ] && mkdir -p "$HOME/.docker/cli-plugins"
+[ ! -d "$HOME/.ssh" ] && mkdir -p "$HOME/.ssh"
 
 export PATH=$PATH:$HOME/.local/bin
 # shellcheck disable=SC2016

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,10 @@ if [ "$(uname)" != "Darwin" ]; then
   exit 1
 fi
 
-mkdir -p "$HOME"/.local/bin "$HOME"/.docker/cli-plugins
+# Create directories.
+[ -d "$HOME/.local/bin" ] && mkdir -p "$HOME/.local/bin"
+[ -d "$HOME/.docker/cli-plugins" ] && mkdir -p "$HOME/.docker/cli-plugins"
+[ -d "$HOME/.ssh" ] && mkdir -p "$HOME/.ssh"
 
 export PATH=$PATH:$HOME/.local/bin
 # shellcheck disable=SC2016
@@ -25,13 +28,13 @@ arm64) CPU=aarch64 ;;
 esac
 curl -o docker.tgz -SL https://download.docker.com/mac/static/stable/"$CPU"/docker-20.10.10.tgz
 tar xzvf docker.tgz
-install docker/docker ~/.local/bin/
-install docker/cli-plugins/docker-buildx ~/.local/bin/
-install docker/cli-plugins/docker-app ~/.local/bin/
+install docker/docker "$HOME/.local/bin/"
+install docker/cli-plugins/docker-buildx "$HOME/.local/bin/"
+install docker/cli-plugins/docker-app "$HOME/.local/bin/"
 (
-  cd ~/.docker/cli-plugins
-  ln -s ~/.local/bin/docker-buildx .
-  ln -s ~/.local/bin/docker-app .
+  cd "$HOME/.docker/cli-plugins"
+  ln -s "$HOME/.local/bin/docker-buildx" .
+  ln -s "$HOME/.local/bin/docker-app" .
 )
 rm -rf docker.tgz docker/
 
@@ -43,14 +46,15 @@ multipass mount --type native "$HOME" docker
 multipass start docker
 multipass set client.primary-name=docker
 
-# Copy the local user's SSH key to the VM.
-mkdir "$HOME"/.ssh
-ssh-keygen -t ed25519 -C "$USER" -f id_ed25519 -N ""
-mv id_ed25519* "$HOME"/.ssh/
-multipass <~/.ssh/id_ed25519.pub exec docker -- bash -c 'cat -- >> ~/.ssh/authorized_keys'
+# Copy the local user's key to the VM (creating it first if it doesn't exist)
+if [ ! -f "$HOME/.ssh/id_ed25519.pub" ]; then
+  ssh-keygen -t ed25519 -C "$USER" -f id_ed25519 -N ""
+  mv id_ed25519* "$HOME/.ssh/"
+fi
+multipass <"$HOME/.ssh/id_ed25519.pub" exec docker -- bash -c 'cat -- >> ~/.ssh/authorized_keys'
 
 # Add SSH configuration for the local Docker VM.
-cat <<EOF >>~/.ssh/config
+cat <<EOF >>"$HOME/.ssh/config"
 Host docker.local
   User ubuntu
   ProxyCommand bash -c "nc $(multipass ls --format csv | grep docker | cut -d ',' -f 3) %p"


### PR DESCRIPTION
Currently the install process fails when the .ssh folder exists. This fixes it by not trying to create the .ssh directory