### PR TITLE
feat: 2024 refresh

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "multipass-installer",
-  "image": "eu.gcr.io/cts-public-images-1/cts-base",
+  "image": "mcr.microsoft.com/devcontainers/base:debian-12",
   "features": {
     "ghcr.io/devcontainers/features/python:1": {},
     "ghcr.io/devcontainers-contrib/features/markdownlint-cli:1": {},

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,12 @@
 {
-  "name": "cts-base",
+  "name": "multipass-installer",
   "image": "eu.gcr.io/cts-public-images-1/cts-base",
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {},
+    "ghcr.io/devcontainers-contrib/features/markdownlint-cli:1": {},
+    "ghcr.io/devcontainers-contrib/features/gh-cli:1": {},
+    "ghcr.io/dhoeric/features/google-cloud-cli:1": {}
+  },
   "customizations": {
     "vscode": {
       "extensions": [
@@ -10,6 +16,9 @@
         "timonwong.shellcheck"
       ]
     }
+  },
+  "postAttachCommand": {
+    "pre-commit": "pipx install pre-commit && pre-commit install",
+    "detect-secrets": "pipx install detect-secrets" // pragma: allowlist secret
   }
-  // "postStartCommand": "pre-commit install"
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,112 @@
+{
+  "version": "1.4.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {},
+  "generated_at": "2024-09-17T10:29:26Z"
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Cloud Technology Solutions
+Copyright (c) 2024 Qodea
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ Enter your password when prompted.
 Now just clone a repository containing a devcontainer configuration and select
 `Reopen in Container` to open it in the Docker VM.
 
-## Troubleshooting
+## FAQs
+
+### _It's not working?_
 
 When initially running the installer script, make sure you cloned to somewhere
-other than a protected MacOS directory (such as `Desktop`). The recommended
-option is to create `$HOME/Developer` (which MacOS automatically assigns a nice
-icon) and clone to there. Otherwise you may get mounting issues where Docker
-complains that the current directory doesn't exist.
+other than a protected MacOS directory (such as `Desktop`). Otherwise you may
+get mounting issues where Docker complains that the current directory doesn't
+exist.
 
 Likewise, if you're cloning to a protected directory (e.g. under `Documents`)
 then you may find that your containers fail to mount the directory. Either move
@@ -44,15 +45,14 @@ install the binary or remove the `credsStore` line from `~/.docker/config.json`
 
 If the Docker VM ever gets into a state where it won't launch, then delete it
 and launch it again. This means you'll need to re-add keys (and remove the old
-ones from your keystore) and re-mount your home directory:
+ones from your keystore) and re-mount your home directory. A helper script is
+supplied to do this for you:
 
 ```sh
 ./rebuild.sh
 ```
 
-## FAQs
-
-### _How can I customise the amount of CPUs and memory allocated to the Virtual Machine?_
+### _Can I customise the CPUs and memory allocated to the Virtual Machine?_
 
 You can do this by setting the values in Multipass:
 
@@ -60,18 +60,27 @@ You can do this by setting the values in Multipass:
 ./resize.sh
 ```
 
-### _Does the script need to mount my entire home directory onto the Virtual Machine?_
+### _Does the script need to mount my entire home directory?_
 
-You don't _need_ to have the `$HOME` directory mounted, but it's recommended.
+Previous versions of the installer mounted the whole of `$HOME` into the
+container. This isn't strictly necessary, and you can get away with just
+mounting the `Developer` directory (the recommended directory for keeping code
+in MacOS - create it and it gets a nice icon and everything).
 
-The script has been tested with specific non-protected mounts and has worked
-without errors. Refer to the Troubleshooting section of this README.
-
-You can change mountpoints like so:
+You can use the provider helper script to update your mounts like so:
 
 ```sh
 ./remount.sh
 ```
+
+### _Can I forward X connections from Docker images to my desktop?_
+
+You can. First install [XQuartz](https://www.xquartz.org/) and log out and in
+again. Then open XQuartz (in `/Applications/Utilities`) and in Settings,
+disable authentication and enable network connections. You can now use `xhost`
+to allow connections to the XQuartz server from the Multipass VM and use `-e`
+to set `DISPLAY` properly to connect back to the host. See the provided
+`x11.sh` for an example.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -74,23 +74,26 @@ multipass start docker
 
 You don't _need_ to have the `$HOME` directory mounted, but it's recommended.
 
-The script has been tested with specific non-protected mounts and has worked without errors. Refer to the Troubleshooting section of this README.
+The script has been tested with specific non-protected mounts and has worked
+without errors. Refer to the Troubleshooting section of this README.
 
 You can change mountpoints like so:
 
 ```sh
 multipass stop docker
 multipass umount docker:"$HOME"
-multipass mount --type native "$HOME/my_developer_dir" docker # /my_developer_dir would contain all your devcontainer-supported repositories
+multipass mount --type native "$HOME/my_developer_dir" docker
+# /my_developer_dir would contain all your devcontainer-supported repositories
 multipass start docker
 ```
 
 ## TODO
 
 -   Add a test suite.
+-   Test / ask for existing SSH keys.
 
 ## License
 
-(C) CTS 2023
+(C) Qodea 2024
 
 MIT License, see [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ You can change mountpoints like so:
 
 ## TODO
 
+-   Update to the next official Multipass release after 1.14.0 once MacOS
+    Sequoia support is fixed.
 -   Add a test suite.
 -   Test / ask for existing SSH keys.
 -   Add parameters to helper scripts.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ You can change mountpoints like so:
 -   Test for the script being run from `~/Desktop`, `~/Documents` or
     `~/Downloads` and error out as these are protected.
 -   Test for `docker-credential-osxkeychain` and fix.
+-   Improve pre-commit config.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -47,14 +47,7 @@ and launch it again. This means you'll need to re-add keys (and remove the old
 ones from your keystore) and re-mount your home directory:
 
 ```sh
-multipass delete docker
-multipass purge
-multipass launch docker
-multipass stop docker
-multipass mount --type native "$HOME" docker
-multipass start docker
-multipass <~/.ssh/id_ed25519.pub exec docker -- bash -c 'cat -- >> ~/.ssh/authorized_keys'
-ssh-keygen -R docker.local
+./rebuild.sh
 ```
 
 ## FAQs
@@ -64,10 +57,7 @@ ssh-keygen -R docker.local
 You can do this by setting the values in Multipass:
 
 ```sh
-multipass stop docker
-multipass set local.docker.cpus=4
-multipass set local.docker.memory=8GiB
-multipass start docker
+./resize.sh
 ```
 
 ### _Does the script need to mount my entire home directory onto the Virtual Machine?_
@@ -80,17 +70,17 @@ without errors. Refer to the Troubleshooting section of this README.
 You can change mountpoints like so:
 
 ```sh
-multipass stop docker
-multipass umount docker:"$HOME"
-multipass mount --type native "$HOME/my_developer_dir" docker
-# /my_developer_dir would contain all your devcontainer-supported repositories
-multipass start docker
+./remount.sh
 ```
 
 ## TODO
 
 -   Add a test suite.
 -   Test / ask for existing SSH keys.
+-   Add parameters to helper scripts.
+-   Test for the script being run from `~/Desktop`, `~/Documents` or
+    `~/Downloads` and error out as these are protected.
+-   Test for `docker-credential-osxkeychain` and fix.
 
 ## License
 

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,9 @@ export PATH=$PATH:$HOME/.local/bin
 echo 'export PATH=$PATH:$HOME/.local/bin' | tee -a "$HOME"/.zshrc "$HOME"/.bash_profile
 
 # Install Multipass.
-curl -o multipass.pkg -SL https://github.com/canonical/multipass/releases/download/v1.12.2/multipass-1.12.2+mac-Darwin.pkg
+# Temporary fix for MacOS 15.0 Sequoia. TODO: use the next official release.
+# curl -o multipass.pkg -SL https://github.com/canonical/multipass/releases/download/v1.14.0/multipass-1.12.2+mac-Darwin.pkg
+curl -o multipass.pkg -SL https://multipass-ci.s3.amazonaws.com/pr661/multipass-1.15.0-dev.2929.pr661%2Bgc67ef6641.mac-Darwin.pkg
 sudo installer -pkg multipass.pkg -target /
 rm multipass.pkg
 
@@ -23,7 +25,10 @@ rm multipass.pkg
 CPU=$(uname -m)
 CPU_BUILDX=amd64
 case $CPU in
-arm64) CPU=aarch64; CPU_BUILDX=arm64 ;;
+arm64)
+  CPU=aarch64
+  CPU_BUILDX=arm64
+  ;;
 esac
 curl -o docker.tgz -SL https://download.docker.com/mac/static/stable/"$CPU"/docker-24.0.5.tgz
 tar xzvf docker.tgz

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ echo 'export PATH=$PATH:$HOME/.local/bin' | tee -a "$HOME"/.zshrc "$HOME"/.bash_
 
 # Install Multipass.
 # Temporary fix for MacOS 15.0 Sequoia. TODO: use the next official release.
-# curl -o multipass.pkg -SL https://github.com/canonical/multipass/releases/download/v1.14.0/multipass-1.12.2+mac-Darwin.pkg
+# curl -o multipass.pkg -SL https://github.com/canonical/multipass/releases/download/v1.14.0/multipass-1.14.0+mac-Darwin.pkg
 curl -o multipass.pkg -SL https://multipass-ci.s3.amazonaws.com/pr661/multipass-1.15.0-dev.2929.pr661%2Bgc67ef6641.mac-Darwin.pkg
 sudo installer -pkg multipass.pkg -target /
 rm multipass.pkg

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ if [ "$(uname)" != "Darwin" ]; then
 fi
 
 # Create directories.
-mkdir -p "$HOME/.local/bin" "$HOME/.docker/cli-plugins" "$HOME/.ssh"
+mkdir -p "$HOME/.local/bin" "$HOME/.docker/cli-plugins" "$HOME/.ssh" "$HOME/Developer"
 
 export PATH=$PATH:$HOME/.local/bin
 # shellcheck disable=SC2016
@@ -45,7 +45,7 @@ rm -rf docker.tgz docker/ docker-buildx
 # multipass set local.driver=qemu
 multipass launch docker
 multipass stop docker
-multipass mount --type native "$HOME" docker
+multipass mount --type native "$HOME/Developer" docker
 multipass start docker
 multipass set client.primary-name=docker
 

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -4,7 +4,7 @@ multipass delete docker
 multipass purge
 multipass launch docker
 multipass stop docker
-multipass mount --type native "$HOME" docker
+multipass mount --type native "$HOME/Developer" docker
 multipass start docker
 multipass <~/.ssh/id_ed25519.pub exec docker -- bash -c 'cat -- >> ~/.ssh/authorized_keys'
 ssh-keygen -R docker.local

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+multipass delete docker
+multipass purge
+multipass launch docker
+multipass stop docker
+multipass mount --type native "$HOME" docker
+multipass start docker
+multipass <~/.ssh/id_ed25519.pub exec docker -- bash -c 'cat -- >> ~/.ssh/authorized_keys'
+ssh-keygen -R docker.local

--- a/remount.sh
+++ b/remount.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+multipass stop docker
+multipass umount docker:"$HOME"
+multipass mount --type native "$HOME/my_developer_dir" docker
+# /my_developer_dir would contain all your devcontainer-supported repositories
+multipass start docker

--- a/remount.sh
+++ b/remount.sh
@@ -3,5 +3,4 @@
 multipass stop docker
 multipass umount docker:"$HOME"
 multipass mount --type native "$HOME/Developer" docker
-# /my_developer_dir would contain all your devcontainer-supported repositories
 multipass start docker

--- a/remount.sh
+++ b/remount.sh
@@ -2,6 +2,6 @@
 
 multipass stop docker
 multipass umount docker:"$HOME"
-multipass mount --type native "$HOME/my_developer_dir" docker
+multipass mount --type native "$HOME/Developer" docker
 # /my_developer_dir would contain all your devcontainer-supported repositories
 multipass start docker

--- a/resize.sh
+++ b/resize.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+multipass stop docker
+multipass set local.docker.cpus=4
+multipass set local.docker.memory=8GiB
+multipass start docker

--- a/x11.sh
+++ b/x11.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+# simple x11 forwarding example.
+# 192.168.64.10 is the Docker VM in Multipass.
+# 192.168.61.1 is the local machine.
+# Disable authentication and enable nework connections in XQuartz.
+
+xhost 192.168.64.10
+docker run -e DISPLAY=192.168.64.1:0 jess/firefox

--- a/x11.sh
+++ b/x11.sh
@@ -5,5 +5,6 @@
 # 192.168.61.1 is the local machine.
 # Disable authentication and enable nework connections in XQuartz.
 
-xhost 192.168.64.10
-docker run -e DISPLAY=192.168.64.1:0 jess/firefox
+open /Applications/Utilities/XQuartz.app
+xhost "$(multipass ls --format csv | grep docker | cut -d ',' -f 3)"                          # 192.168.64.10
+docker run -e DISPLAY="$(ifconfig bridge100 | grep 'inet ' | cut -f 2 -d ' '):0" jess/firefox # 192.168.61.1


### PR DESCRIPTION
- Use vanilla devcontainer with features instead of an internal one.
- Move shell script lines in documentation into their own helpers.
- Temporary fix for MacOS 15.0 Sequoia.
- Add pre-commit and detect-secrets.
- Minor shellcheck linting.
- Update copyrights.