### PR TITLE
Updates multipass to 1.14.1 to fix Sequoia issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,6 @@ to set `DISPLAY` properly to connect back to the host. See the provided
 
 ## TODO
 
--   Update to the next official Multipass release after 1.14.0 once MacOS
-    Sequoia support is fixed.
 -   Add a test suite.
 -   Test / ask for existing SSH keys.
 -   Add parameters to helper scripts.

--- a/install.sh
+++ b/install.sh
@@ -15,9 +15,7 @@ export PATH=$PATH:$HOME/.local/bin
 echo 'export PATH=$PATH:$HOME/.local/bin' | tee -a "$HOME"/.zshrc "$HOME"/.bash_profile
 
 # Install Multipass.
-# Temporary fix for MacOS 15.0 Sequoia. TODO: use the next official release.
-# curl -o multipass.pkg -SL https://github.com/canonical/multipass/releases/download/v1.14.0/multipass-1.14.0+mac-Darwin.pkg
-curl -o multipass.pkg -SL https://multipass-ci.s3.amazonaws.com/pr661/multipass-1.15.0-dev.2929.pr661%2Bgc67ef6641.mac-Darwin.pkg
+curl -o multipass.pkg -SL https://github.com/canonical/multipass/releases/download/v1.14.1/multipass-1.14.1+mac-Darwin.pkg
 sudo installer -pkg multipass.pkg -target /
 rm multipass.pkg
 


### PR DESCRIPTION
Updates install.sh to the latest version of Multipass, 1.14.1, which fixes the Sequoia startup issue in 1.14.0.

Updates README.md to remove the update TODO.